### PR TITLE
Proposed solution to filter document content by namespaces

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,6 +16,7 @@ namespace MarkdownWikiGenerator
             // put dll & xml on same diretory.
             var target = "UniRx.dll"; // :)
             string dest = "md";
+            string namespaceMatch = string.Empty;
             if (args.Length == 1)
             {
                 target = args[0];
@@ -25,8 +26,14 @@ namespace MarkdownWikiGenerator
                 target = args[0];
                 dest = args[1];
             }
+            else if (args.Length == 3) 
+            {
+                target = args[0];
+                dest = args[1];
+                namespaceMatch = args[2];
+            }
 
-            var types = MarkdownGenerator.Load(target);
+            var types = MarkdownGenerator.Load(target, namespaceMatch);
 
             // Home Markdown Builder
             var homeBuilder = new MarkdownBuilder();

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Clone and open solution, build console application.
 Command Line Argument
 - `[0]` = dll src path
 - `[1]` = output directory 
+- `[2]` = regex pattern to select namespaces (optional)
 
 Put .xml on same directory, use document comment for generate.
 


### PR DESCRIPTION
An optional namespace regular expression is added, which can be used to select the namespaces that must be present in the resulting documentation. It can be useful when you do not need a full description of the assembly. Regular expression allows you to make choices more flexibly.

Related to https://github.com/neuecc/MarkdownGenerator/issues/4