### PR TITLE
Fixed regex in see/paramref parsing; Added ref linking

### DIFF
--- a/MarkdownGenerator.cs
+++ b/MarkdownGenerator.cs
@@ -158,8 +158,7 @@ namespace MarkdownWikiGenerator
             mb.AppendLine();
 
             var desc = commentLookup[type.FullName].FirstOrDefault(x => x.MemberType == MemberType.Type)?.Summary ?? "";
-            if (desc != "")
-            {
+            if (desc != "") {
                 mb.AppendLine(desc);
             }
             {
@@ -216,7 +215,7 @@ namespace MarkdownWikiGenerator
             XmlDocumentComment[] comments = new XmlDocumentComment[0];
             if (File.Exists(xmlPath))
             {
-                comments = VSDocParser.ParseXmlComment(XDocument.Parse(File.ReadAllText(xmlPath)));
+                comments = VSDocParser.ParseXmlComment(XDocument.Parse(File.ReadAllText(xmlPath)), namespaceMatch);
             }
             var commentsLookup = comments.ToLookup(x => x.ClassName);
 

--- a/VSDocParser.cs
+++ b/VSDocParser.cs
@@ -36,31 +36,32 @@ namespace MarkdownWikiGenerator
 
     public static class VSDocParser
     {
+        public static XmlDocumentComment[] ParseXmlComment(XDocument xDocument) {
+            return ParseXmlComment(xDocument, null);
+        }
+
         // cheap, quick hack parser:)
-        public static XmlDocumentComment[] ParseXmlComment(XDocument xDoc)
-        {
-            return xDoc.Descendants("member")
-                .Select(x =>
-                {
+        internal static XmlDocumentComment[] ParseXmlComment(XDocument xDocument, string namespaceMatch) {
+            return xDocument.Descendants("member")
+                .Select(x => {
                     var match = Regex.Match(x.Attribute("name").Value, @"(.):(.+)\.([^.()]+)?(\(.+\)|$)");
                     if (!match.Groups[1].Success) return null;
 
                     var memberType = (MemberType)match.Groups[1].Value[0];
                     if (memberType == MemberType.None) return null;
 
-                    var summaryXml = x.Elements("summary").FirstOrDefault()?.ToString() 
-                        ?? x.Element("summary")?.ToString() 
+                    var summaryXml = x.Elements("summary").FirstOrDefault()?.ToString()
+                        ?? x.Element("summary")?.ToString()
                         ?? "";
                     summaryXml = Regex.Replace(summaryXml, @"<\/?summary>", string.Empty);
                     summaryXml = Regex.Replace(summaryXml, @"<para\s*/>", Environment.NewLine);
-                    summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", ResolveSeeElement);
+                    summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", m => ResolveSeeElement(m, namespaceMatch));
 
                     var parsed = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
-                        
+
                     var summary = parsed;
 
-                    if (summary != "")
-                    {
+                    if (summary != "") {
                         summary = string.Join("  ", summary.Split(new[] { "\r", "\n", "\t" }, StringSplitOptions.RemoveEmptyEntries).Select(y => y.Trim()));
                     }
 
@@ -75,8 +76,7 @@ namespace MarkdownWikiGenerator
                         ? match.Groups[2].Value + "." + match.Groups[3].Value
                         : match.Groups[2].Value;
 
-                    return new XmlDocumentComment
-                    {
+                    return new XmlDocumentComment {
                         MemberType = memberType,
                         ClassName = className,
                         MemberName = match.Groups[3].Value,
@@ -90,10 +90,12 @@ namespace MarkdownWikiGenerator
                 .ToArray();
         }
 
-        private static string ResolveSeeElement(Match m) {
+        private static string ResolveSeeElement(Match m, string ns) {
             var typeName = m.Groups[1].Value;
-            if (typeName.Split('.')[0] == "AnyQ") {
-                return $"[{typeName}]({Regex.Replace(typeName, $"\\.(?:.(?!\\.))+$", me => me.Groups[0].Value.Replace(".", "#").ToLower())})";
+            if (!string.IsNullOrWhiteSpace(ns)) {
+                if (typeName.StartsWith(ns)) {
+                    return $"[{typeName}]({Regex.Replace(typeName, $"\\.(?:.(?!\\.))+$", me => me.Groups[0].Value.Replace(".", "#").ToLower())})";
+                }
             }
             return $"`{typeName}`";
         }

--- a/VSDocParser.cs
+++ b/VSDocParser.cs
@@ -53,10 +53,11 @@ namespace MarkdownWikiGenerator
                         ?? "";
                     summaryXml = Regex.Replace(summaryXml, @"<\/?summary>", string.Empty);
                     summaryXml = Regex.Replace(summaryXml, @"<para\s*/>", Environment.NewLine);
-                    summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
-                    var parsed = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
+                    summaryXml = Regex.Replace(summaryXml, @"<see cref=""\w:([^\""]*)""\s*\/>", ResolveSeeElement);
 
-                    var summary = parsed; // ((string)x.Elements("summary").First()) ?? "";
+                    var parsed = Regex.Replace(summaryXml, @"<(type)*paramref name=""([^\""]*)""\s*\/>", e => $"`{e.Groups[1].Value}`");
+                        
+                    var summary = parsed;
 
                     if (summary != "")
                     {
@@ -87,6 +88,14 @@ namespace MarkdownWikiGenerator
                 })
                 .Where(x => x != null)
                 .ToArray();
+        }
+
+        private static string ResolveSeeElement(Match m) {
+            var typeName = m.Groups[1].Value;
+            if (typeName.Split('.')[0] == "AnyQ") {
+                return $"[{typeName}]({Regex.Replace(typeName, $"\\.(?:.(?!\\.))+$", me => me.Groups[0].Value.Replace(".", "#").ToLower())})";
+            }
+            return $"`{typeName}`";
         }
 
         class Item1EqualityCompaerer<T1, T2> : EqualityComparer<Tuple<T1, T2>>


### PR DESCRIPTION
So I found a flaw in my previous commit that prevented correctly parsing multiple see/paramref elements in the summary correctly.  That's fixed.

Also, now those references can actually be links to their respective entries in the markdown if you supply the namespace to the command line.  (see [here](https://github.com/DoublePrecisionSoftware/AnyQ/wiki/AnyQ))