### PR TITLE
Fixed InvalidCastException when underlying type of an Enum cannot be casted to Int32

### DIFF
--- a/MarkdownGenerator.cs
+++ b/MarkdownGenerator.cs
@@ -183,7 +183,7 @@ namespace MarkdownWikiGenerator
             if (type.IsEnum)
             {
                 var enums = Enum.GetNames(type)
-                    .Select(x => new { Name = x, Value = ((Int32)Enum.Parse(type, x)) })
+                    .Select(x => new { Name = x, Value = (Convert.ChangeType(Enum.Parse(type, x), Enum.GetUnderlyingType(type))) })
                     .OrderBy(x => x.Value)
                     .ToArray();
 

--- a/MarkdownGenerator.cs
+++ b/MarkdownGenerator.cs
@@ -182,8 +182,10 @@ namespace MarkdownWikiGenerator
 
             if (type.IsEnum)
             {
+                var underlyingEnumType = Enum.GetUnderlyingType(type);
+
                 var enums = Enum.GetNames(type)
-                    .Select(x => new { Name = x, Value = (Convert.ChangeType(Enum.Parse(type, x), Enum.GetUnderlyingType(type))) })
+                    .Select(x => new { Name = x, Value = (Convert.ChangeType(Enum.Parse(type, x), underlyingEnumType)) })
                     .OrderBy(x => x.Value)
                     .ToArray();
 


### PR DESCRIPTION
Fixes #10 